### PR TITLE
Version updated with minor change for compatibility issue with the la…

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,13 +12,13 @@
 
             var exceeded = mutation.target.classList.contains('wp-smush-exceed-limit');
             if (exceeded) {
-                document.querySelector('.wp-smush-all').click()
+                document.querySelector('.wp-smush-resume-scan').click()
             }
         });
     });
 
     observer.observe(
-        document.querySelector('.wp-smush-bulk-progress-bar-wrapper'),
+        document.querySelector('#wp-smush-progress-dialog'),
         { attributes: true }
         );
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,13 @@
 === Disable Bulk Smush Limit of WP Smushit ===
 Plugin Name: Disable Bulk Smush Limit of WP Smushit
-Version: 2.0.0
+Version: 2.0.1
 Author: obiPlabon
 Author URI: https://obiPlabon.im/
 Contributors: obiplabon
 Tags: wp smushit, image, compression, performance, optimization, disable
-Requires at least: 4.6
-Tested up to: 5.2.4
-Requires PHP: 5.4
+Requires at least: 5.6
+Tested up to: 5.7.2
+Requires PHP: 7.4
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -30,6 +30,10 @@ Yes, it's completely free forever.
 = Will there be any problem from WP Smushit? ==
 
 == Changelog ==
+
+= 2.0.1 =
+
+* Fix: Version updated with minor change for compatibility issue with the latest **WP Smushit**
 
 = 2.0.0 =
 

--- a/wp-nonstop-smushit.php
+++ b/wp-nonstop-smushit.php
@@ -11,7 +11,7 @@
  * Plugin Name: Smush Nonstop
  * Plugin URI:  https://github.com/obiPlabon/wp-nonstop-smushit
  * Description: Disable bulk smash limit and enjoy one of the most exciting premium feature of <a href="https://wordpress.org/plugins/wp-smushit/" target="_blank">WP Smashit</a> completely FREE 😉
- * Version:     2.0.0
+ * Version:     2.0.1
  * Author:      obiPlabon
  * Author URI:  https://obiPlabon.im/
  * License:     GPLv2
@@ -46,7 +46,7 @@ if ( ! class_exists( 'WP_Nonstop_Smushit' ) ) {
         /**
          * Plugin version number
          */
-        const VERSION = '2.0.0';
+        const VERSION = '2.0.1';
 
         /**
          * Plugin slug


### PR DESCRIPTION
This fixes issue with recent changes to WP-SMUSHIT bulk smush that broke wp-nonstop-smushit plugin observer logic.

ID of querySelector to observe changed, as well as the class of the querySelector used to click for resume scan.

I've tested this locally and on various client sites, and the changes appear to be working as expected.
Thanks,
-voxx